### PR TITLE
Only report 250 noisiest application instances & CF pushable

### DIFF
--- a/accumulator/internal/app/collector.go
+++ b/accumulator/internal/app/collector.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"sort"
 	"time"
 
 	"code.cloudfoundry.org/noisy-neighbor-nozzle/accumulator/internal/datadogreporter"
@@ -15,6 +16,14 @@ type Rate struct {
 	Counts    map[string]uint64 `json:"counts"`
 }
 
+// Points is used to sort datadogreporter Points by count
+type Points []datadogreporter.Point
+
+func (p Points) Len() int           { return len(p) }
+func (p Points) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p Points) Less(i, j int) bool { return p[i].Points[0][1] > p[j].Points[0][1] }
+
+// Authenticator is used to refresh the authentication token.
 type Authenticator interface {
 	RefreshAuthToken() (string, error)
 }
@@ -22,14 +31,15 @@ type Authenticator interface {
 // Collector handles fetch rates form multiple nozzles and summing their
 // rates.
 type Collector struct {
-	nozzles    []string
-	auth       Authenticator
-	httpClient *http.Client
+	nozzles     []string
+	auth        Authenticator
+	httpClient  *http.Client
+	reportLimit int
 }
 
 // NewCollector initializes and returns a new Collector.
-func NewCollector(nozzles []string, auth Authenticator) *Collector {
-	return &Collector{
+func NewCollector(nozzles []string, auth Authenticator, opts ...CollectorOption) *Collector {
+	c := &Collector{
 		nozzles: nozzles,
 		auth:    auth,
 		httpClient: &http.Client{
@@ -38,7 +48,14 @@ func NewCollector(nozzles []string, auth Authenticator) *Collector {
 				DisableKeepAlives: true,
 			},
 		},
+		reportLimit: 250,
 	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	return c
 }
 
 // BuildPoints satisfies the datadogreporter PointBuilder interface. It will
@@ -61,7 +78,12 @@ func (c *Collector) BuildPoints(timestamp int64) ([]datadogreporter.Point, error
 		})
 	}
 
-	return ddPoints, nil
+	sort.Sort(Points(ddPoints))
+	if len(ddPoints) <= c.reportLimit {
+		return ddPoints, nil
+	}
+
+	return ddPoints[0:c.reportLimit], nil
 }
 
 // rates will collect all the rates from all the nozzles.
@@ -105,6 +127,19 @@ func (c *Collector) rates(timestamp int64) (Rate, error) {
 	}
 
 	return Sum(results), nil
+}
+
+// CollectorOption is a type of func that can be used for optional configuration
+// settings for the Collector.
+type CollectorOption func(c *Collector)
+
+// WithReportLimit sets the limit of application instances to report to datadog.
+// Example: If report limit is set to 100, only the 100 noisest application
+// instances will be reported.
+func WithReportLimit(n int) CollectorOption {
+	return func(c *Collector) {
+		c.reportLimit = n
+	}
 }
 
 // Sum will take a slice of Rate and sum all their counts together to create a

--- a/accumulator/internal/app/collector_test.go
+++ b/accumulator/internal/app/collector_test.go
@@ -21,7 +21,11 @@ var _ = Describe("Collector", func() {
 			testServer, requests := setupTestServer(ts1, http.StatusOK)
 			defer testServer.Close()
 
-			c := app.NewCollector([]string{testServer.URL}, &spyAuthenticator{})
+			c := app.NewCollector(
+				[]string{testServer.URL},
+				&spyAuthenticator{},
+				"app-guid",
+			)
 
 			points, err := c.BuildPoints(ts1)
 			Expect(err).ToNot(HaveOccurred())
@@ -31,6 +35,7 @@ var _ = Describe("Collector", func() {
 			Expect(requests).To(Receive(&request))
 			Expect(request.url.Path).To(Equal(fmt.Sprintf("/state/%d", ts1)))
 			Expect(request.headers.Get("Authorization")).To(Equal("Bearer valid-token"))
+			Expect(request.headers.Get("X-CF-APP-INSTANCE")).To(Equal("app-guid:0"))
 
 			point := findPointWithTag("application.instance:app-1/0", points)
 			Expect(point).ToNot(BeZero())
@@ -55,13 +60,20 @@ var _ = Describe("Collector", func() {
 			defer serverA.Close()
 			defer serverB.Close()
 
-			_ = requestsA
-			_ = requestsB
-
-			c := app.NewCollector([]string{serverA.URL, serverB.URL}, &spyAuthenticator{})
+			c := app.NewCollector(
+				[]string{serverA.URL, serverB.URL},
+				&spyAuthenticator{},
+				"app-guid",
+			)
 
 			points, err := c.BuildPoints(ts1)
 			Expect(err).ToNot(HaveOccurred())
+
+			var request request
+			Expect(requestsA).To(Receive(&request))
+			Expect(request.headers.Get("X-CF-APP-INSTANCE")).To(Equal("app-guid:0"))
+			Expect(requestsB).To(Receive(&request))
+			Expect(request.headers.Get("X-CF-APP-INSTANCE")).To(Equal("app-guid:1"))
 
 			point := findPointWithTag("application.instance:app-1/0", points)
 			Expect(point).ToNot(BeZero())
@@ -81,17 +93,15 @@ var _ = Describe("Collector", func() {
 		It("limits the number of points returned", func() {
 			ts1 := time.Now().Add(time.Minute).Unix()
 
-			serverA, requestsA := setupTestServer(ts1, http.StatusOK)
-			serverB, requestsB := setupTestServer(ts1, http.StatusOK)
+			serverA, _ := setupTestServer(ts1, http.StatusOK)
+			serverB, _ := setupTestServer(ts1, http.StatusOK)
 			defer serverA.Close()
 			defer serverB.Close()
-
-			_ = requestsA
-			_ = requestsB
 
 			c := app.NewCollector(
 				[]string{serverA.URL, serverB.URL},
 				&spyAuthenticator{},
+				"",
 				app.WithReportLimit(1),
 			)
 
@@ -111,6 +121,30 @@ var _ = Describe("Collector", func() {
 			}))
 		})
 
+		It("does not send X-CF-APP-INSTANCE header if nozzle app guid is empty", func() {
+			ts1 := time.Now().Add(time.Minute).Unix()
+
+			serverA, requestsA := setupTestServer(ts1, http.StatusOK)
+			serverB, requestsB := setupTestServer(ts1, http.StatusOK)
+			defer serverA.Close()
+			defer serverB.Close()
+
+			c := app.NewCollector(
+				[]string{serverA.URL, serverB.URL},
+				&spyAuthenticator{},
+				"",
+			)
+
+			_, err := c.BuildPoints(ts1)
+			Expect(err).ToNot(HaveOccurred())
+
+			var request request
+			Expect(requestsA).To(Receive(&request))
+			Expect(request.headers.Get("X-CF-APP-INSTANCE")).To(Equal(""))
+			Expect(requestsB).To(Receive(&request))
+			Expect(request.headers.Get("X-CF-APP-INSTANCE")).To(Equal(""))
+		})
+
 		It("returns an error if any of the nozzles return a non 200 status code", func() {
 			ts1 := time.Now().Add(time.Minute).Unix()
 			serverA, _ := setupTestServer(ts1, http.StatusOK)
@@ -118,7 +152,11 @@ var _ = Describe("Collector", func() {
 			defer serverA.Close()
 			defer serverB.Close()
 
-			c := app.NewCollector([]string{serverA.URL, serverB.URL}, &spyAuthenticator{})
+			c := app.NewCollector(
+				[]string{serverA.URL, serverB.URL},
+				&spyAuthenticator{},
+				"app-guid",
+			)
 
 			_, err := c.BuildPoints(ts1)
 			Expect(err).To(HaveOccurred())

--- a/accumulator/internal/app/config.go
+++ b/accumulator/internal/app/config.go
@@ -19,7 +19,15 @@ type Config struct {
 	ReportInterval time.Duration `env:"REPORT_INTERVAL"`
 	ReporterHost   string        `env:"REPORTER_HOST"`
 	ReportLimit    int           `env:"REPORT_LIMIT"`
-	TLSConfig      *tls.Config
+
+	// VCapApplication is used to detect whether or not the application is
+	// deployed as a CF application. If it is the NOZZLE_COUNT and
+	// NOZZLE_APP_GUID  are required.
+	VCapApplication string `env:"VCAP_APPLICATION"`
+	NozzleCount     int    `env:"NOZZLE_COUNT"`
+	NozzleAppGUID   string `env:"NOZZLE_APP_GUID"`
+
+	TLSConfig *tls.Config
 }
 
 // LoadConfig loads the configuration settings from the current environment.
@@ -32,6 +40,30 @@ func LoadConfig() Config {
 
 	if err := envstruct.Load(&cfg); err != nil {
 		log.Fatalf("failed to load config: %s", err)
+	}
+
+	// If deployed as a CF application, validate additional required
+	// configuration and update NozzleAddrs to have same number of addresses as
+	// NozzleCount.
+	if cfg.VCapApplication != "" {
+		if cfg.NozzleCount == 0 {
+			log.Fatalf("failed to load config: NOZZLE_COUNT must not be 0 when deployed as CF application")
+		}
+
+		if len(cfg.NozzleAddrs) != 1 {
+			log.Fatalf("failed to load config: NOZZLE_ADDRS must contain only 1 address when deployed as a CF application")
+		}
+
+		if cfg.NozzleAppGUID == "" {
+			log.Fatalf("failed to load config: NOZZLE_APP_GUID cannot be empty when deployed as CF application")
+		}
+
+		addrs := make([]string, 0, cfg.NozzleCount)
+		for i := 0; i < cfg.NozzleCount; i++ {
+			addrs = append(addrs, cfg.NozzleAddrs[0])
+		}
+
+		cfg.NozzleAddrs = addrs
 	}
 
 	cfg.TLSConfig = &tls.Config{InsecureSkipVerify: cfg.SkipCertVerify}

--- a/accumulator/internal/app/config.go
+++ b/accumulator/internal/app/config.go
@@ -8,6 +8,7 @@ import (
 	envstruct "code.cloudfoundry.org/go-envstruct"
 )
 
+// Config stores configuration data for the accumulator.
 type Config struct {
 	UAAAddr        string        `env:"UAA_ADDR,        required"`
 	ClientID       string        `env:"CLIENT_ID,       required"`
@@ -17,12 +18,15 @@ type Config struct {
 	SkipCertVerify bool          `env:"SKIP_CERT_VERIFY"`
 	ReportInterval time.Duration `env:"REPORT_INTERVAL"`
 	ReporterHost   string        `env:"REPORTER_HOST"`
+	ReportLimit    int           `env:"REPORT_LIMIT"`
 	TLSConfig      *tls.Config
 }
 
+// LoadConfig loads the configuration settings from the current environment.
 func LoadConfig() Config {
 	cfg := Config{
 		ReportInterval: time.Minute,
+		ReportLimit:    250,
 		SkipCertVerify: false,
 	}
 

--- a/accumulator/main.go
+++ b/accumulator/main.go
@@ -21,7 +21,7 @@ func main() {
 	)
 
 	log.Printf("initializing collector with nozzles: %+v", cfg.NozzleAddrs)
-	collector := app.NewCollector(cfg.NozzleAddrs, auth,
+	collector := app.NewCollector(cfg.NozzleAddrs, auth, cfg.NozzleAppGUID,
 		app.WithReportLimit(cfg.ReportLimit),
 	)
 

--- a/accumulator/main.go
+++ b/accumulator/main.go
@@ -21,7 +21,9 @@ func main() {
 	)
 
 	log.Printf("initializing collector with nozzles: %+v", cfg.NozzleAddrs)
-	collector := app.NewCollector(cfg.NozzleAddrs, auth)
+	collector := app.NewCollector(cfg.NozzleAddrs, auth,
+		app.WithReportLimit(cfg.ReportLimit),
+	)
 
 	log.Printf("initializing datadog reporter")
 	reporter := datadogreporter.New(


### PR DESCRIPTION
* Limits the number of application instances reported to Datadog to 250 by default
* Detects if CF deployed, if it is the accumulator requires additional configuration and sends the `X-CF-APP-INSTANCE` header with the request to ensure the request hits a specific instance.