### PR TITLE
Add truncate_timestamp query parameter to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ instance.
 - `timestamp` - Unix timetamp truncated to the nozzles `POLLING_INTERVAL`
   (Default is 1 minute).
 
+### Query Parameter
+
+- `truncate_timestamp` - Optional query parameter to truncate the given
+  timestamp to the by the configured `RATE_INTERVAL` (Default is 1 minute). If
+  `true` timestamp will be truncated, otherwise it will not be modified.
+
 #### Example
 
 ```

--- a/cmd/accumulator/app/accumulator.go
+++ b/cmd/accumulator/app/accumulator.go
@@ -32,7 +32,7 @@ func New(cfg Config) *Accumulator {
 	c := collector.New(cfg.NozzleAddrs, a, cfg.NozzleAppGUID, nil,
 		collector.WithHTTPClient(client),
 	)
-	s := web.NewServer(cfg.Port, a.CheckToken, c,
+	s := web.NewServer(cfg.Port, a.CheckToken, c, cfg.RateInterval,
 		web.WithLogWriter(cfg.LogWriter),
 	)
 

--- a/cmd/accumulator/app/config.go
+++ b/cmd/accumulator/app/config.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"time"
 
 	envstruct "code.cloudfoundry.org/go-envstruct"
 )
@@ -18,6 +19,10 @@ type Config struct {
 	NozzleAddrs    []string `env:"NOZZLE_ADDRS,    required"`
 	Port           uint16   `env:"PORT,            required"`
 	SkipCertVerify bool     `env:"SKIP_CERT_VERIFY"`
+
+	// RateInterval is used with the rates endpoint. This should match the
+	// POLLING_INTERVAL of the nozzle.
+	RateInterval time.Duration `env:"RATE_INTERVAL"`
 
 	// VCapApplication is used to detect whether or not the application is
 	// deployed as a CF application. If it is the NOZZLE_COUNT and
@@ -34,6 +39,7 @@ type Config struct {
 func LoadConfig() Config {
 	cfg := Config{
 		SkipCertVerify: false,
+		RateInterval:   time.Minute,
 		LogWriter:      os.Stdout,
 	}
 

--- a/cmd/nozzle/app/nozzle.go
+++ b/cmd/nozzle/app/nozzle.go
@@ -55,7 +55,13 @@ func New(cfg Config) *Nozzle {
 		store.WithPollingInterval(cfg.PollingInterval),
 		store.WithMaxRateBuckets(cfg.MaxRateBuckets),
 	)
-	s := web.NewServer(cfg.Port, authenticator.CheckToken, a, web.WithLogWriter(cfg.LogWriter))
+	s := web.NewServer(
+		cfg.Port,
+		authenticator.CheckToken,
+		a,
+		cfg.PollingInterval,
+		web.WithLogWriter(cfg.LogWriter),
+	)
 
 	return &Nozzle{
 		cfg:        cfg,

--- a/pkg/web/rate_handler.go
+++ b/pkg/web/rate_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gorilla/mux"
@@ -24,7 +25,7 @@ func RatesShow(store RateStore, rateInterval time.Duration) http.Handler {
 			return
 		}
 
-		if r.URL.Query().Get("truncate_timestamp") == "true" {
+		if strings.ToLower(r.URL.Query().Get("truncate_timestamp")) == "true" {
 			ts := time.Unix(timestamp, 0)
 			timestamp = ts.Truncate(rateInterval).Unix()
 		}

--- a/pkg/web/rate_handler_test.go
+++ b/pkg/web/rate_handler_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	"code.cloudfoundry.org/noisy-neighbor-nozzle/pkg/web"
 	"github.com/gorilla/mux"
@@ -13,13 +14,13 @@ import (
 )
 
 var _ = Describe("RateHandlers", func() {
-	Describe("RateShow", func() {
+	Describe("RatesShow", func() {
 		It("returns a 404 when timestamp is not a number", func() {
-			h := web.RatesShow(&rateStore{})
+			h := web.RatesShow(&rateStore{}, time.Minute)
 			router := mux.NewRouter()
-			router.Handle("/state/{timestamp}", h)
+			router.Handle("/rates/{timestamp}", h)
 
-			r, err := http.NewRequest("", "/state/not-a-number", nil)
+			r, err := http.NewRequest("", "/rates/not-a-number", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			w := httptest.NewRecorder()
@@ -29,11 +30,11 @@ var _ = Describe("RateHandlers", func() {
 		})
 
 		It("returns a 404 when a rate is not found", func() {
-			h := web.RatesShow(&rateStore{rateError: errors.New("not found")})
+			h := web.RatesShow(&rateStore{rateError: errors.New("not found")}, time.Minute)
 			router := mux.NewRouter()
-			router.Handle("/state/{timestamp}", h)
+			router.Handle("/rates/{timestamp}", h)
 
-			r, err := http.NewRequest("", "/state/12345", nil)
+			r, err := http.NewRequest("", "/rates/12345", nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			w := httptest.NewRecorder()
@@ -43,7 +44,7 @@ var _ = Describe("RateHandlers", func() {
 		})
 
 		It("returns a 400 when there is no timestamp string", func() {
-			h := web.RatesShow(&rateStore{rateError: errors.New("not found")})
+			h := web.RatesShow(&rateStore{rateError: errors.New("not found")}, time.Minute)
 
 			r, err := http.NewRequest("", "", nil)
 			Expect(err).ToNot(HaveOccurred())
@@ -52,6 +53,28 @@ var _ = Describe("RateHandlers", func() {
 			h.ServeHTTP(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		Describe("query parameters", func() {
+			It("truncates the timestamp", func() {
+				rs := &rateStore{}
+				h := web.RatesShow(rs, time.Minute)
+				router := mux.NewRouter()
+				router.Handle("/rates/{timestamp}", h)
+
+				r, err := http.NewRequest(
+					http.MethodGet,
+					"/rates/1515426389?truncate_timestamp=true",
+					nil,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+
+				Expect(w.Code).To(Equal(http.StatusOK))
+				Expect(rs.rateTimestamp).To(Equal(int64(1515426360)))
+			})
 		})
 	})
 })

--- a/pkg/web/rate_handler_test.go
+++ b/pkg/web/rate_handler_test.go
@@ -75,6 +75,26 @@ var _ = Describe("RateHandlers", func() {
 				Expect(w.Code).To(Equal(http.StatusOK))
 				Expect(rs.rateTimestamp).To(Equal(int64(1515426360)))
 			})
+
+			It("is case insensitive", func() {
+				rs := &rateStore{}
+				h := web.RatesShow(rs, time.Minute)
+				router := mux.NewRouter()
+				router.Handle("/rates/{timestamp}", h)
+
+				r, err := http.NewRequest(
+					http.MethodGet,
+					"/rates/1515426389?truncate_timestamp=TRUE",
+					nil,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				w := httptest.NewRecorder()
+				router.ServeHTTP(w, r)
+
+				Expect(w.Code).To(Equal(http.StatusOK))
+				Expect(rs.rateTimestamp).To(Equal(int64(1515426360)))
+			})
 		})
 	})
 })

--- a/pkg/web/server.go
+++ b/pkg/web/server.go
@@ -29,7 +29,13 @@ type Server struct {
 }
 
 // NewServer opens a TCP listener and returns an initialized Server.
-func NewServer(port uint16, ct CheckToken, rs RateStore, opts ...ServerOption) *Server {
+func NewServer(
+	port uint16,
+	ct CheckToken,
+	rs RateStore,
+	rateInterval time.Duration,
+	opts ...ServerOption,
+) *Server {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		log.Fatalf("failed to start listener: %d", port)
@@ -39,7 +45,7 @@ func NewServer(port uint16, ct CheckToken, rs RateStore, opts ...ServerOption) *
 
 	router := mux.NewRouter()
 
-	router.Handle("/rates/{timestamp:[0-9]+}", RatesShow(rs)).
+	router.Handle("/rates/{timestamp:[0-9]+}", RatesShow(rs, rateInterval)).
 		Methods(http.MethodGet)
 
 	authMiddleware := AdminAuthMiddleware(ct)


### PR DESCRIPTION
This adds the `truncate_timestamp` query parameter to the HTTP API.